### PR TITLE
Fix docker error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Docker
 
 docker build . -t go-playground
-docker run -it --rm -p 3000:3000 -v ./:/go/src/app go-playground
+docker run -it --rm -p 3000:3000 -v $PWD:/go/src/app go-playground
 
 or
 


### PR DESCRIPTION
```
docker: Error response from daemon: create ./: "./" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```